### PR TITLE
Remove Special Thanks section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,6 @@ View the online documentation [here](https://frc-elastic.gitbook.io/docs)
 ## Building and Contributing
 View the instructions for building code and making contributions to the project in the [CONTRIBUTING.md](CONTRIBUTING.md) file
 
-## Special Thanks
-
-This dashboard wouldn't have been made without the help and inspiration from the following people
-
-* [Michael Jansen](https://github.com/mjansen4857) from Team 3015
-* [Jonah](https://github.com/jwbonner) from Team 6328
-* [Oh yes 10 FPS](https://github.com/oh-yes-0-fps) from Team 3173
-* [Jason](https://github.com/jasondaming) and [Peter](https://github.com/PeterJohnson) from WPILib
-* All mentors and advisors of Team 353, the POBots
-
 ## Contributors
 
 <a href="https://github.com/Gold872/elastic_dashboard/graphs/contributors">


### PR DESCRIPTION
When Elastic was being created and first launched, there weren't many people involved, and those who were, either directly or indirectly, had a huge role in it. Initially, a section in the README was added to thank several people who were responsible for either the app's existence or for a major feature. As the app continued developing and more users and contributors emerged, the list of people who played a big role grew, but the README had not changed one bit. With how long it has been since the initial release, the "Special Thanks" section has become outdated to the point where updating it wouldn't make sense, since it would be a long list.

Instead, the "Contributors" section will be there for all of the amazing individuals who have taken the time to improve Elastic in some way or another.